### PR TITLE
demo: the agent answers the action with new UI

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -33,6 +33,10 @@
 	let seq = 0;
 	let idleTimer: ReturnType<typeof setTimeout> | undefined;
 
+	// Identifies this browser to the dev mock agent (see api/agent/+server.ts).
+	const sessionId =
+		globalThis.crypto?.randomUUID?.() ?? `demo-${Math.random().toString(36).slice(2)}`;
+
 	// Declared after the state it touches: makeClient() reads `seq`/`feed`, so
 	// calling it any earlier hits the temporal dead zone during SSR.
 	let client = $state(makeClient());
@@ -65,7 +69,12 @@
 		const next = new A2uiClient({
 			transport: isStatic
 				? createDemoReplayTransport()
-				: createHttpTransport({ url: '/api/agent' }),
+				: // The header rides on both the stream request and outbound actions,
+					// so the mock agent replies to this browser only.
+					createHttpTransport({
+						url: '/api/agent',
+						headers: { 'x-demo-session': sessionId }
+					}),
 			supportedCatalogIds: catalog.ids,
 			// Every inbound envelope and every outbound action lands in the feed,
 			// so the wire and the pixels it produces sit side by side.

--- a/src/routes/api/agent/+server.ts
+++ b/src/routes/api/agent/+server.ts
@@ -16,8 +16,15 @@ import type { RendererToAgent } from '$lib/protocol/types.js';
 
 import { DEMO_SCRIPT, bookingResponse } from '../../demo-script.js';
 
-/** Open response streams, so an inbound action can push UI back. Dev-only. */
-const listeners = new Set<(chunk: string) => void>();
+/**
+ * Open response streams, keyed by the caller's session so a reply reaches only
+ * the browser that acted — a module-global set would broadcast one visitor's
+ * booking (and their email) to every open stream. Dev-only mock agent.
+ */
+const listeners = new Map<string, Set<(chunk: string) => void>>();
+
+/** The demo page sends this on both the stream request and its actions. */
+const sessionOf = (request: Request) => request.headers.get('x-demo-session') ?? 'anonymous';
 
 export const POST: RequestHandler = async ({ request }) => {
 	// Renderer -> agent messages arrive on the same URL, tagged by content type.
@@ -28,7 +35,8 @@ export const POST: RequestHandler = async ({ request }) => {
 		const action = message.action;
 		if (action) {
 			const steps = action.name === 'book_another' ? DEMO_SCRIPT.slice(1) : bookingResponse(action);
-			// Fire and forget: the reply lands on whatever streams are open.
+			const session = sessionOf(request);
+			// Fire and forget: the reply lands on this session's open streams.
 			void (async () => {
 				for (const step of steps) {
 					if ('__pause' in step) {
@@ -36,7 +44,7 @@ export const POST: RequestHandler = async ({ request }) => {
 						continue;
 					}
 					const line = JSON.stringify(step) + '\n';
-					for (const send of listeners) send(line);
+					for (const send of listeners.get(session) ?? []) send(line);
 				}
 			})();
 		}
@@ -45,6 +53,7 @@ export const POST: RequestHandler = async ({ request }) => {
 	}
 
 	const encoder = new TextEncoder();
+	const session = sessionOf(request);
 
 	const stream = new ReadableStream<Uint8Array>({
 		async start(controller) {
@@ -52,12 +61,15 @@ export const POST: RequestHandler = async ({ request }) => {
 			const send = (chunk: string) => {
 				if (!closed) controller.enqueue(encoder.encode(chunk));
 			};
-			listeners.add(send);
+			const forSession = listeners.get(session) ?? new Set();
+			forSession.add(send);
+			listeners.set(session, forSession);
 
 			const finish = () => {
 				if (closed) return;
 				closed = true;
-				listeners.delete(send);
+				forSession.delete(send);
+				if (forSession.size === 0) listeners.delete(session);
 				try {
 					controller.close();
 				} catch {

--- a/src/routes/api/agent/+server.ts
+++ b/src/routes/api/agent/+server.ts
@@ -5,17 +5,42 @@
  * deliberately sends leaf components *before* `root` — that ordering is legal
  * and is exactly what the buffering rule exists for. Watching this endpoint is
  * the fastest way to see progressive rendering behave.
+ *
+ * The stream stays open after the script finishes so the agent can answer an
+ * action with more UI, which is how A2UI actually works: an action is a
+ * request, not a form submission.
  */
 
 import type { RequestHandler } from './$types';
 import type { RendererToAgent } from '$lib/protocol/types.js';
 
-import { DEMO_SCRIPT } from '../../demo-script.js';
+import { DEMO_SCRIPT, bookingResponse } from '../../demo-script.js';
+
+/** Open response streams, so an inbound action can push UI back. Dev-only. */
+const listeners = new Set<(chunk: string) => void>();
+
 export const POST: RequestHandler = async ({ request }) => {
 	// Renderer -> agent messages arrive on the same URL, tagged by content type.
 	if ((request.headers.get('content-type') ?? '').includes('a2ui')) {
 		const message = (await request.json()) as RendererToAgent;
 		console.log('[demo agent] received', JSON.stringify(message, null, 2));
+
+		const action = message.action;
+		if (action) {
+			const steps = action.name === 'book_another' ? DEMO_SCRIPT.slice(1) : bookingResponse(action);
+			// Fire and forget: the reply lands on whatever streams are open.
+			void (async () => {
+				for (const step of steps) {
+					if ('__pause' in step) {
+						await new Promise((resolve) => setTimeout(resolve, step.__pause));
+						continue;
+					}
+					const line = JSON.stringify(step) + '\n';
+					for (const send of listeners) send(line);
+				}
+			})();
+		}
+
 		return new Response(null, { status: 204 });
 	}
 
@@ -23,18 +48,33 @@ export const POST: RequestHandler = async ({ request }) => {
 
 	const stream = new ReadableStream<Uint8Array>({
 		async start(controller) {
-			try {
-				for (const step of DEMO_SCRIPT) {
-					if (request.signal.aborted) break;
-					if ('__pause' in step) {
-						await new Promise((resolve) => setTimeout(resolve, step.__pause));
-						continue;
-					}
-					controller.enqueue(encoder.encode(JSON.stringify(step) + '\n'));
+			let closed = false;
+			const send = (chunk: string) => {
+				if (!closed) controller.enqueue(encoder.encode(chunk));
+			};
+			listeners.add(send);
+
+			const finish = () => {
+				if (closed) return;
+				closed = true;
+				listeners.delete(send);
+				try {
+					controller.close();
+				} catch {
+					// Already closed by the client disconnecting.
 				}
-			} finally {
-				controller.close();
+			};
+			request.signal.addEventListener('abort', finish, { once: true });
+
+			for (const step of DEMO_SCRIPT) {
+				if (closed) return;
+				if ('__pause' in step) {
+					await new Promise((resolve) => setTimeout(resolve, step.__pause));
+					continue;
+				}
+				send(JSON.stringify(step) + '\n');
 			}
+			// Deliberately not closed: the agent may still have something to say.
 		}
 	});
 

--- a/src/routes/demo-script.ts
+++ b/src/routes/demo-script.ts
@@ -9,7 +9,7 @@
  * legal, and watching the buffering rule handle it is the point of the demo.
  */
 
-import type { AgentToRenderer } from '$lib/protocol/types.js';
+import type { AgentToRenderer, RendererAction } from '$lib/protocol/types.js';
 import { BASIC_CATALOG_ID } from '$lib/protocol/types.js';
 import { createEmitter, type Transport } from '$lib/transport/types.js';
 
@@ -229,29 +229,112 @@ export const DEMO_SCRIPT: (AgentToRenderer | { __pause: number })[] = [
 ];
 
 /**
+ * What the agent streams back when the user books.
+ *
+ * An action is a request, not a submission: the agent decides what happens
+ * next and answers with more UI. Here it replaces the form with a
+ * confirmation, which is also the clearest demonstration that
+ * `updateComponents` re-points `root` at a different tree — no page
+ * navigation, no client-side routing, just data.
+ */
+export function bookingResponse(action: RendererAction): (AgentToRenderer | { __pause: number })[] {
+	const context = (action.context ?? {}) as { partySize?: unknown; email?: unknown };
+	const partySize = Number(context.partySize ?? 2);
+	const email = String(context.email ?? '');
+	const reference = `BV-${String(Math.floor(Math.random() * 9000) + 1000)}`;
+
+	return [
+		{ __pause: 550 },
+		{
+			version: 'v1.0',
+			updateDataModel: {
+				surfaceId: SURFACE,
+				path: '/booking',
+				value: { reference, partySize, email, time: '7:30 PM', table: 'Patio' }
+			}
+		},
+		{ __pause: 350 },
+		{
+			version: 'v1.0',
+			updateComponents: {
+				surfaceId: SURFACE,
+				components: [
+					// Re-pointing `root` swaps the whole surface. The form's components
+					// still exist; they are simply no longer reachable from the root.
+					{ id: 'root', component: 'Column', children: ['confirm_card'], align: 'stretch' },
+					{ id: 'confirm_card', component: 'Card', child: 'confirm_body' },
+					{
+						id: 'confirm_body',
+						component: 'Column',
+						children: ['confirm_head', 'confirm_detail', 'confirm_note', 'confirm_actions']
+					},
+					{ id: 'confirm_head', component: 'Row', children: ['confirm_icon', 'confirm_title'] },
+					{ id: 'confirm_icon', component: 'Icon', name: 'check' },
+					{ id: 'confirm_title', component: 'Text', text: "You're booked" },
+					{
+						id: 'confirm_detail',
+						component: 'Text',
+						text: {
+							call: 'formatString',
+							args: {
+								value:
+									'Table for ${/booking/partySize} at ${/booking/time} — ${/booking/table}. ' +
+									'Reference ${/booking/reference}.'
+							}
+						}
+					},
+					{
+						id: 'confirm_note',
+						component: 'Text',
+						variant: 'caption',
+						text: {
+							call: 'formatString',
+							args: { value: 'Confirmation sent to ${/booking/email}. See you tonight.' }
+						}
+					},
+					{ id: 'confirm_actions', component: 'Row', children: ['confirm_again'] },
+					{ id: 'confirm_again_label', component: 'Text', text: 'Book another table' },
+					{
+						id: 'confirm_again',
+						component: 'Button',
+						variant: 'primary',
+						child: 'confirm_again_label',
+						action: { event: { name: 'book_another' } }
+					}
+				]
+			}
+		}
+	];
+}
+
+/**
  * Replays the script in the browser, honouring the pauses — the transport the
- * static demo runs on. Also a live example of how small a Transport is.
+ * static demo runs on. Also a live example of how small a Transport is: it
+ * answers actions the way the real agent does, so the round trip completes.
  */
 export function createDemoReplayTransport(): Transport {
 	const emitter = createEmitter();
 	let cancelled = false;
 
-	return {
-		async start() {
-			for (const step of DEMO_SCRIPT) {
-				if (cancelled) return;
-				if ('__pause' in step) {
-					await new Promise((resolve) => setTimeout(resolve, step.__pause));
-					continue;
-				}
-				emitter.emit(step);
+	async function play(steps: (AgentToRenderer | { __pause: number })[]) {
+		for (const step of steps) {
+			if (cancelled) return;
+			if ('__pause' in step) {
+				await new Promise((resolve) => setTimeout(resolve, step.__pause));
+				continue;
 			}
-		},
+			emitter.emit(step);
+		}
+	}
+
+	return {
+		start: () => play(DEMO_SCRIPT),
 		subscribe: emitter.subscribe,
 		send(message) {
-			// No agent on the other side of a static page; the demo's action log
-			// (wired via onAction) is the visible result.
-			console.log('[demo] action (static mode, not delivered):', message);
+			const action = message.action;
+			if (!action) return;
+			// `book_another` restarts the script; anything else confirms the booking.
+			void play(action.name === 'book_another' ? DEMO_SCRIPT.slice(1) : bookingResponse(action));
 		},
 		close() {
 			cancelled = true;


### PR DESCRIPTION
Fixes the gap [polina-c spotted](https://github.com/a2ui-project/a2ui/pull/2290#discussion_r0) while reviewing the ecosystem listing PR: clicking **Book table** sent the action, but the surface never changed — so the round trip looked broken. It was. The demo agent had nothing to say back.

Now it answers:

1. `updateDataModel` writes the booking (reference, party size, time) into the data model
2. `updateComponents` re-points `root` at a confirmation tree

That second step is the clearest demonstration of the model in the whole demo: an action is a *request*, not a form submission, and "navigating" to a new screen is just more data. **Book another table** replays the original stream.

Both delivery modes behave the same way — the replay transport (static/Pages build) answers in-process, and the dev server now keeps its JSONL stream open after the script instead of closing it, pushing the reply to open streams when the action POST arrives.

Verified headless: book → confirmation renders with the right reference and email → *Book another table* → form returns. Console clean, 83 + 19 tests, check and publint green.