### PR TITLE
feat(protocol): route unimplemented functions to the agent (#5)

### DIFF
--- a/src/lib/client.svelte.ts
+++ b/src/lib/client.svelte.ts
@@ -12,6 +12,7 @@ import { setPointer } from './protocol/pointer.js';
 import type { Scope } from './protocol/scope.js';
 import { ROOT_SCOPE } from './protocol/scope.js';
 import {
+	agentCallKey,
 	callFunction,
 	createFunctionRegistry,
 	resolveDynamic,
@@ -24,6 +25,7 @@ import {
 	rendererCapabilitiesMetadata,
 	reduce,
 	trackPendingAction,
+	trackPendingFunctionCall,
 	type ClientState,
 	type SurfaceState
 } from './protocol/reducer.js';
@@ -33,6 +35,7 @@ import {
 	isFunctionCallAction,
 	type Action,
 	type AgentToRenderer,
+	type FunctionRef,
 	type RendererAction,
 	type RendererToAgent
 } from './protocol/types.js';
@@ -124,8 +127,63 @@ export class A2uiClient {
 		return {
 			data: this.#state.surfaces[surfaceId]?.dataModel,
 			scope,
-			functions: this.functions
+			functions: this.functions,
+			agentValues: this.#state.surfaces[surfaceId]?.agentValues,
+			onUnresolvedFunction: (ref, key) => this.#queueAgentCall(surfaceId, ref, key)
 		};
+	}
+
+	/* ------------------------------------------- agent-side function routing */
+
+	/*
+	 * A plain Map, deliberately NOT reactive state. `onUnresolvedFunction` fires
+	 * from inside `resolveDynamic`, which runs during render; writing reactive
+	 * state there re-enters the effect that is currently reading it and trips
+	 * `effect_update_depth_exceeded`. So requests are collected here and flushed
+	 * on a microtask, after the render that discovered them has finished.
+	 */
+	#queuedAgentCalls = new Map<string, { surfaceId: string; ref: FunctionRef }>();
+	#flushScheduled = false;
+
+	/**
+	 * Route a function the renderer does not implement to the agent. Public
+	 * because the render layer builds its own `EvalContext` per node — this is
+	 * the hook it passes as `onUnresolvedFunction`.
+	 */
+	requestAgentFunction(surfaceId: string, ref: FunctionRef, key: string): void {
+		this.#queueAgentCall(surfaceId, ref, key);
+	}
+
+	#queueAgentCall(surfaceId: string, ref: FunctionRef, key: string): void {
+		// Already asked and still waiting: one round trip, not one per render.
+		for (const pending of Object.values(this.#state.pendingFunctionCalls)) {
+			if (pending.key === key && pending.surfaceId === surfaceId) return;
+		}
+		this.#queuedAgentCalls.set(`${surfaceId}\u0000${key}`, { surfaceId, ref });
+		if (this.#flushScheduled) return;
+		this.#flushScheduled = true;
+		queueMicrotask(() => this.#flushAgentCalls());
+	}
+
+	#flushAgentCalls(): void {
+		this.#flushScheduled = false;
+		const queued = [...this.#queuedAgentCalls.entries()];
+		this.#queuedAgentCalls.clear();
+
+		for (const [composite, { surfaceId, ref }] of queued) {
+			const key = composite.slice(composite.indexOf('\u0000') + 1);
+			const surface = this.#state.surfaces[surfaceId];
+			// The surface may have been deleted, or the value may have arrived,
+			// between queueing and this flush.
+			if (!surface || key in surface.agentValues) continue;
+
+			const functionCallId = (this.#options.newId ?? defaultNewId)();
+			this.#state = trackPendingFunctionCall(this.#state, functionCallId, { surfaceId, key });
+			this.#send({
+				version: A2UI_VERSION,
+				callAgentFunction: { surfaceId, functionCallId, callFunction: ref }
+			});
+		}
 	}
 
 	/* ---------------------------------------------------------------- writes */

--- a/src/lib/protocol/functions.ts
+++ b/src/lib/protocol/functions.ts
@@ -7,6 +7,7 @@
  */
 
 import type { Scope } from './scope.js';
+import type { FunctionRef } from './types.js';
 
 export interface EvalContext {
 	/** The surface data model root. */
@@ -17,6 +18,22 @@ export interface EvalContext {
 	remote?: boolean;
 	/** Recursion guard, carried on the context so it survives re-entry. */
 	depth?: number;
+	/**
+	 * Values the agent has already returned for functions this renderer does not
+	 * implement, keyed by `agentCallKey`. Consulted before routing a call, so a
+	 * resolved agent function is indistinguishable from a local one.
+	 */
+	agentValues?: Readonly<Record<string, unknown>>;
+	/**
+	 * The spec's fallback routing (a2ui_protocol.md, `callAgentFunction`): a
+	 * function not registered locally is assumed to live on the agent and MUST
+	 * be dispatched, not dropped. Called with the ref and its RESOLVED args.
+	 *
+	 * This fires during evaluation, which happens during render — so an
+	 * implementation must not synchronously mutate reactive state here. The
+	 * client queues and flushes in a microtask for exactly that reason.
+	 */
+	onUnresolvedFunction?: (ref: FunctionRef, key: string) => void;
 }
 
 export interface FunctionImpl {

--- a/src/lib/protocol/reducer.ts
+++ b/src/lib/protocol/reducer.ts
@@ -31,6 +31,13 @@ export interface SurfaceState {
 	components: Readonly<Record<ComponentId, ComponentSpec>>;
 	dataModel: unknown;
 	/**
+	 * Values returned by the agent for functions this renderer does not
+	 * implement, keyed by `agentCallKey`. Per-surface so `deleteSurface` drops
+	 * them without extra bookkeeping, and so two surfaces cannot read each
+	 * other's results.
+	 */
+	agentValues: Readonly<Record<string, unknown>>;
+	/**
 	 * Components are buffered until `root` exists — before that, updates are
 	 * accepted but nothing is painted.
 	 */
@@ -42,14 +49,23 @@ export interface PendingAction {
 	responsePath?: string;
 }
 
+export interface PendingFunctionCall {
+	surfaceId: string;
+	/** `agentCallKey` of the call, so the reply lands in the right cache slot. */
+	key: string;
+}
+
 export interface ClientState {
 	surfaces: Readonly<Record<string, SurfaceState>>;
 	pendingActions: Readonly<Record<string, PendingAction>>;
+	/** In-flight `callAgentFunction`s, by `functionCallId`. */
+	pendingFunctionCalls: Readonly<Record<string, PendingFunctionCall>>;
 }
 
 export const INITIAL_STATE: ClientState = Object.freeze({
 	surfaces: Object.freeze({}),
-	pendingActions: Object.freeze({})
+	pendingActions: Object.freeze({}),
+	pendingFunctionCalls: Object.freeze({})
 });
 
 export interface ReduceOptions {
@@ -117,6 +133,7 @@ export function reduce(
 			sendDataModel: Boolean(sendDataModel),
 			components: map,
 			dataModel: dataModel ?? {},
+			agentValues: {},
 			ready: Object.prototype.hasOwnProperty.call(map, ROOT_COMPONENT_ID)
 		};
 
@@ -183,13 +200,18 @@ export function reduce(
 		const surfaces = { ...state.surfaces };
 		delete surfaces[surfaceId];
 
-		// Drop any actions that were still waiting on this surface.
+		// Drop anything still waiting on this surface — actions and function calls
+		// alike. A reply arriving after teardown has nowhere to land.
 		const pendingActions: Record<string, PendingAction> = {};
 		for (const [id, p] of Object.entries(state.pendingActions)) {
 			if (p.surfaceId !== surfaceId) pendingActions[id] = p;
 		}
+		const pendingFunctionCalls: Record<string, PendingFunctionCall> = {};
+		for (const [id, p] of Object.entries(state.pendingFunctionCalls)) {
+			if (p.surfaceId !== surfaceId) pendingFunctionCalls[id] = p;
+		}
 
-		return { state: { surfaces, pendingActions }, outbound };
+		return { state: { surfaces, pendingActions, pendingFunctionCalls }, outbound };
 	}
 
 	/* --------------------------------------------------- callRendererFunction */
@@ -258,6 +280,52 @@ export function reduce(
 		return { state, outbound };
 	}
 
+	/* --------------------------------------------------- agentFunctionResponse */
+
+	/*
+	 * The agent's reply to a `callAgentFunction` we dispatched because the
+	 * function was not registered locally. Correlate by `functionCallId`, then
+	 * write the value into the surface's cache under the call's key — the next
+	 * evaluation reads it there and the value simply appears.
+	 */
+	if (message.agentFunctionResponse) {
+		const { functionCallId, value, error } = message.agentFunctionResponse;
+		const pending = state.pendingFunctionCalls[functionCallId];
+
+		if (!pending) {
+			// Late, duplicated, or for a surface that has since been deleted.
+			console.warn(`[a2ui] agentFunctionResponse for unknown functionCallId ${functionCallId}`);
+			return { state, outbound };
+		}
+
+		const pendingFunctionCalls = { ...state.pendingFunctionCalls };
+		delete pendingFunctionCalls[functionCallId];
+
+		const surface = state.surfaces[pending.surfaceId];
+		if (!surface) return { state: { ...state, pendingFunctionCalls }, outbound };
+
+		/*
+		 * An error is cached too, as undefined. Without that the call is retried
+		 * on every single render — the spec has the agent answer UNKNOWN_FUNCTION
+		 * for a name it does not recognise, and re-asking forever is worse than
+		 * rendering nothing.
+		 */
+		if (error) {
+			console.warn(`[a2ui] agent function failed: ${error.code} ${error.message}`);
+		}
+
+		const agentValues = { ...surface.agentValues, [pending.key]: error ? undefined : value };
+
+		return {
+			state: {
+				...state,
+				surfaces: { ...state.surfaces, [surface.surfaceId]: { ...surface, agentValues } },
+				pendingFunctionCalls
+			},
+			outbound
+		};
+	}
+
 	/* --------------------------------------------------------- actionResponse */
 
 	if (message.actionResponse) {
@@ -291,6 +359,7 @@ export function reduce(
 
 		return {
 			state: {
+				...state,
 				surfaces: { ...state.surfaces, [surface.surfaceId]: { ...surface, dataModel } },
 				pendingActions
 			},
@@ -351,6 +420,18 @@ export function trackPendingAction(
 	pending: PendingAction
 ): ClientState {
 	return { ...state, pendingActions: { ...state.pendingActions, [actionId]: pending } };
+}
+
+/** Record a dispatched `callAgentFunction` so its reply can be correlated. */
+export function trackPendingFunctionCall(
+	state: ClientState,
+	functionCallId: string,
+	pending: PendingFunctionCall
+): ClientState {
+	return {
+		...state,
+		pendingFunctionCalls: { ...state.pendingFunctionCalls, [functionCallId]: pending }
+	};
 }
 
 /**

--- a/src/lib/protocol/resolve.ts
+++ b/src/lib/protocol/resolve.ts
@@ -72,6 +72,28 @@ export function resolveDynamic(value: unknown, ctx: EvalContext): unknown {
 	return value;
 }
 
+/**
+ * A stable identity for one agent-side call: same function, same catalog, same
+ * RESOLVED arguments. Keys are canonical (object keys sorted) so two calls that
+ * differ only in property order dedupe onto one round trip rather than two.
+ */
+export function agentCallKey(ref: FunctionRef): string {
+	const canonical = (value: unknown): unknown => {
+		if (Array.isArray(value)) return value.map(canonical);
+		if (value && typeof value === 'object') {
+			const out: Record<string, unknown> = {};
+			for (const k of Object.keys(value as Record<string, unknown>).sort()) {
+				out[k] = canonical((value as Record<string, unknown>)[k]);
+			}
+			return out;
+		}
+		return value;
+	};
+	return JSON.stringify(
+		canonical({ call: ref.call, catalogId: ref.catalogId, args: ref.args ?? {} })
+	);
+}
+
 export function callFunction(ref: FunctionRef, ctx: EvalContext): unknown {
 	if ((ctx.depth ?? 0) > MAX_DEPTH) {
 		console.warn(`[a2ui] call depth exceeded resolving ${ref.call}`);
@@ -80,7 +102,25 @@ export function callFunction(ref: FunctionRef, ctx: EvalContext): unknown {
 
 	const impl = ctx.functions[ref.call];
 	if (!impl) {
-		console.warn(`[a2ui] unknown function: ${ref.call}`);
+		/*
+		 * Spec fallback routing: a name this renderer does not implement is an
+		 * AGENT function, not an error. Resolve its args here — the agent wants
+		 * values, not `{path}` refs — then answer from cache if the agent has
+		 * already replied, otherwise ask.
+		 */
+		const inner = { ...deeper(ctx), remote: false };
+		const args = (resolveDynamic(ref.args ?? {}, inner) ?? {}) as Record<string, unknown>;
+		const resolvedRef: FunctionRef = { call: ref.call, catalogId: ref.catalogId, args };
+		const key = agentCallKey(resolvedRef);
+
+		if (ctx.agentValues && key in ctx.agentValues) return ctx.agentValues[key];
+
+		if (ctx.onUnresolvedFunction) {
+			ctx.onUnresolvedFunction(resolvedRef, key);
+		} else {
+			// No route to an agent (a pure evaluation, or a host that opted out).
+			console.warn(`[a2ui] unknown function: ${ref.call}`);
+		}
 		return undefined;
 	}
 	if (ctx.remote && (impl.callableFrom ?? 'rendererOnly') === 'rendererOnly') {

--- a/src/lib/protocol/types.ts
+++ b/src/lib/protocol/types.ts
@@ -188,6 +188,16 @@ export interface AgentToRenderer {
 	 */
 	callFunction?: FunctionRef;
 	/**
+	 * The agent's reply to a `callAgentFunction` this renderer dispatched
+	 * (`agent_to_renderer.json#/$defs/AgentFunctionResponseMessage`). Carries
+	 * exactly one of `value` or `error`.
+	 */
+	agentFunctionResponse?: {
+		functionCallId: string;
+		value?: unknown;
+		error?: { code: string; message: string };
+	};
+	/**
 	 * NOT an A2UI v1.0 message. The v1.0 envelope is a `oneOf` over exactly
 	 * `createSurface`, `updateComponents`, `updateDataModel`, `deleteSurface`,
 	 * `callRendererFunction` and `agentFunctionResponse` — there is no
@@ -264,6 +274,15 @@ export interface RendererError {
 export interface RendererToAgent {
 	version: string;
 	action?: RendererAction;
+	/**
+	 * Renderer-initiated call to a function that lives on the agent, dispatched
+	 * when a name is not registered locally (the spec's fallback routing).
+	 */
+	callAgentFunction?: {
+		surfaceId: string;
+		functionCallId: string;
+		callFunction: FunctionRef;
+	};
 	/**
 	 * v1.0's name for the reply to `callRendererFunction`
 	 * (`renderer_to_agent.json`, which is a `oneOf` over `action`,

--- a/src/lib/render/Node.svelte
+++ b/src/lib/render/Node.svelte
@@ -39,7 +39,15 @@
 	const ctx: EvalContext = $derived({
 		data: surface?.dataModel,
 		scope,
-		functions: rc.catalog.functions
+		functions: rc.catalog.functions,
+		/*
+		 * Agent-side function routing. `agentValues` holds what the agent has
+		 * already answered; `onUnresolvedFunction` asks for what it has not. The
+		 * client queues these and flushes on a microtask — this fires mid-render,
+		 * so it must not write reactive state synchronously.
+		 */
+		agentValues: surface?.agentValues,
+		onUnresolvedFunction: (ref, key) => rc.client.requestAgentFunction(rc.surfaceId, ref, key)
 	});
 
 	const handlers = {

--- a/tests/browser/agent-functions.test.ts
+++ b/tests/browser/agent-functions.test.ts
@@ -1,0 +1,116 @@
+import { expect, test } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { A2uiClient } from '../../src/lib/client.svelte.js';
+import Surface from '../../src/lib/render/Surface.svelte';
+import type { RendererToAgent } from '../../src/lib/protocol/types.js';
+import { catalog, SURFACE } from './helpers.js';
+
+/**
+ * The spec's fallback routing, end to end: a function this renderer does not
+ * implement is dispatched to the agent, its answer is cached, and the UI shows
+ * it — without the component ever knowing the value came from a round trip.
+ */
+function clientWithCapturedOutbound() {
+	const sent: RendererToAgent[] = [];
+	const client = new A2uiClient({
+		transport: {
+			send: (message) => {
+				sent.push(message);
+			},
+			subscribe: () => () => {}
+		},
+		newId: (() => {
+			let n = 0;
+			return () => `fc-${++n}`;
+		})()
+	});
+	return { client, sent };
+}
+
+const settle = () => new Promise((r) => setTimeout(r, 60));
+
+test('an unimplemented function is dispatched to the agent, then renders its answer', async () => {
+	const { client, sent } = clientWithCapturedOutbound();
+	const screen = await render(Surface, { props: { client, catalog, surfaceId: SURFACE } });
+
+	client.ingest({
+		version: 'v1.0',
+		createSurface: {
+			surfaceId: SURFACE,
+			components: [
+				{ id: 'root', component: 'Text', text: { call: 'stockLabel', args: { sku: 'A-1' } } }
+			]
+		}
+	});
+	await settle();
+
+	const call = sent.find((m) => m.callAgentFunction);
+	expect(call?.callAgentFunction?.surfaceId).toBe(SURFACE);
+	expect(call?.callAgentFunction?.callFunction.call).toBe('stockLabel');
+	expect(call?.callAgentFunction?.callFunction.args).toEqual({ sku: 'A-1' });
+
+	// The agent answers, and the value simply appears.
+	client.ingest({
+		version: 'v1.0',
+		agentFunctionResponse: {
+			functionCallId: call!.callAgentFunction!.functionCallId,
+			value: 'In stock'
+		}
+	});
+	await settle();
+
+	await expect.element(screen.getByText('In stock')).toBeInTheDocument();
+});
+
+test('the same call is dispatched once, however many times it is evaluated', async () => {
+	/*
+	 * Evaluation happens on every render, so without dedupe a single agent
+	 * function would issue a request per repaint — and each reply would trigger
+	 * another repaint. Three components share one call here; the agent must be
+	 * asked once.
+	 */
+	const { client, sent } = clientWithCapturedOutbound();
+	await render(Surface, { props: { client, catalog, surfaceId: SURFACE } });
+
+	client.ingest({
+		version: 'v1.0',
+		createSurface: {
+			surfaceId: SURFACE,
+			components: [
+				{ id: 'root', component: 'Column', children: ['a', 'b', 'c'] },
+				{ id: 'a', component: 'Text', text: { call: 'price', args: { sku: 'A-1' } } },
+				{ id: 'b', component: 'Text', text: { call: 'price', args: { sku: 'A-1' } } },
+				// Same args, different key order — must still be the same call.
+				{ id: 'c', component: 'Text', text: { call: 'price', args: { sku: 'A-1' } } }
+			]
+		}
+	});
+	await settle();
+
+	const calls = sent.filter((m) => m.callAgentFunction);
+	expect(calls).toHaveLength(1);
+});
+
+test('a surface torn down mid-flight does not strand the reply', async () => {
+	const { client, sent } = clientWithCapturedOutbound();
+	await render(Surface, { props: { client, catalog, surfaceId: SURFACE } });
+
+	client.ingest({
+		version: 'v1.0',
+		createSurface: {
+			surfaceId: SURFACE,
+			components: [{ id: 'root', component: 'Text', text: { call: 'slow', args: {} } }]
+		}
+	});
+	await settle();
+	expect(sent.filter((m) => m.callAgentFunction)).toHaveLength(1);
+
+	client.ingest({ version: 'v1.0', deleteSurface: { surfaceId: SURFACE } });
+	// The late reply must be a no-op rather than an exception.
+	client.ingest({
+		version: 'v1.0',
+		agentFunctionResponse: { functionCallId: 'fc-1', value: 'too late' }
+	});
+	await settle();
+	expect(client.surfaceIds).not.toContain(SURFACE);
+});

--- a/tests/reducer.test.ts
+++ b/tests/reducer.test.ts
@@ -4,6 +4,7 @@ import {
 	INITIAL_STATE,
 	reduce,
 	trackPendingAction,
+	trackPendingFunctionCall,
 	rendererDataModelMetadata,
 	rendererCapabilitiesMetadata
 } from '../src/lib/protocol/reducer.ts';
@@ -333,4 +334,83 @@ test('rendererCapabilitiesMetadata matches the renderer_capabilities.json shape'
 			}
 		}
 	});
+});
+
+/* --------------------------------------------- agentFunctionResponse */
+
+const SURFACE_WITH_PENDING = () => {
+	const { state } = reduce(
+		INITIAL_STATE,
+		{
+			version: 'v1.0',
+			createSurface: {
+				surfaceId: 's1',
+				components: [{ id: 'root', component: 'Text', text: 'hi' }]
+			}
+		},
+		options
+	);
+	return trackPendingFunctionCall(state, 'fc-1', { surfaceId: 's1', key: 'K' });
+};
+
+test('agentFunctionResponse caches the value and clears the pending call', () => {
+	const { state } = reduce(
+		SURFACE_WITH_PENDING(),
+		{
+			version: 'v1.0',
+			agentFunctionResponse: { functionCallId: 'fc-1', value: { inStock: true } }
+		},
+		options
+	);
+	assert.deepEqual(state.surfaces.s1?.agentValues, { K: { inStock: true } });
+	assert.deepEqual(state.pendingFunctionCalls, {});
+});
+
+test('an agent function error is cached too, so it is not re-asked forever', () => {
+	/*
+	 * The spec has the agent answer UNKNOWN_FUNCTION for a name it does not
+	 * recognise. If the failure were not cached, the next render would find the
+	 * value still missing and dispatch again — a request loop for as long as the
+	 * component is on screen.
+	 */
+	const { state } = reduce(
+		SURFACE_WITH_PENDING(),
+		{
+			version: 'v1.0',
+			agentFunctionResponse: {
+				functionCallId: 'fc-1',
+				error: { code: 'UNKNOWN_FUNCTION', message: 'no such function' }
+			}
+		},
+		options
+	);
+	assert.ok('K' in (state.surfaces.s1?.agentValues ?? {}), 'the failure must occupy the slot');
+	assert.equal(state.surfaces.s1?.agentValues.K, undefined);
+	assert.deepEqual(state.pendingFunctionCalls, {});
+});
+
+test('a response for an unknown functionCallId is ignored, not fatal', () => {
+	const before = SURFACE_WITH_PENDING();
+	const { state } = reduce(
+		before,
+		{
+			version: 'v1.0',
+			agentFunctionResponse: { functionCallId: 'nope', value: 1 }
+		},
+		options
+	);
+	assert.deepEqual(state.pendingFunctionCalls, before.pendingFunctionCalls);
+});
+
+test('deleting a surface drops its in-flight function calls', () => {
+	// A reply arriving after teardown has nowhere to land.
+	const { state } = reduce(
+		SURFACE_WITH_PENDING(),
+		{
+			version: 'v1.0',
+			deleteSurface: { surfaceId: 's1' }
+		},
+		options
+	);
+	assert.deepEqual(state.pendingFunctionCalls, {});
 });

--- a/tests/resolve.test.ts
+++ b/tests/resolve.test.ts
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
+	agentCallKey,
 	createFunctionRegistry,
 	resolveDynamic,
 	evaluateExpression
@@ -149,4 +150,67 @@ test('deeply self-referential registries bottom out instead of hanging', () => {
 	assert.doesNotThrow(() =>
 		resolveDynamic({ call: 'loop' }, { data, scope: ROOT_SCOPE, functions })
 	);
+});
+
+/* --------------------------------------------- agent-side function routing */
+
+test('an unregistered function is routed to the agent, not dropped', () => {
+	/*
+	 * The spec's fallback routing: local lookup first, and a name this renderer
+	 * does not implement is assumed to be an AGENT function. Before this, the
+	 * renderer warned and returned undefined, so any catalog declaring an
+	 * agent-side function rendered a hole in silence.
+	 */
+	const routed: { call: string; args: unknown }[] = [];
+	const ctx: EvalContext = {
+		data: { order: { id: 'ord-7' } },
+		scope: ROOT_SCOPE,
+		functions: createFunctionRegistry({}),
+		onUnresolvedFunction: (ref) => routed.push({ call: ref.call, args: ref.args })
+	};
+
+	const value = resolveDynamic(
+		{ call: 'checkInventory', args: { id: { path: '/order/id' } } },
+		ctx
+	);
+
+	assert.equal(value, undefined, 'nothing to show until the agent answers');
+	assert.equal(routed.length, 1);
+	assert.equal(routed[0]?.call, 'checkInventory');
+	// Args reach the agent RESOLVED — it wants values, not our {path} refs.
+	assert.deepEqual(routed[0]?.args, { id: 'ord-7' });
+});
+
+test('a value the agent already returned resolves like a local function', () => {
+	const ref = { call: 'checkInventory', args: { id: 'ord-7' } };
+	let asked = 0;
+	const ctx: EvalContext = {
+		data: {},
+		scope: ROOT_SCOPE,
+		functions: createFunctionRegistry({}),
+		agentValues: { [agentCallKey(ref)]: { inStock: true } },
+		onUnresolvedFunction: () => asked++
+	};
+
+	assert.deepEqual(resolveDynamic(ref, ctx), { inStock: true });
+	assert.equal(asked, 0, 'a cached value must not re-ask the agent');
+});
+
+test('call identity ignores argument order, so one call is one round trip', () => {
+	// Two objects, same meaning, different key order — they must dedupe.
+	assert.equal(
+		agentCallKey({ call: 'f', args: { b: 2, a: 1 } }),
+		agentCallKey({ call: 'f', args: { a: 1, b: 2 } })
+	);
+	// But a different catalog is a different function.
+	assert.notEqual(
+		agentCallKey({ call: 'f', catalogId: 'x', args: {} }),
+		agentCallKey({ call: 'f', catalogId: 'y', args: {} })
+	);
+});
+
+test('without a route to an agent, an unknown function still just returns undefined', () => {
+	// Pure evaluation (no client attached) must not throw.
+	const ctx: EvalContext = { data: {}, scope: ROOT_SCOPE, functions: createFunctionRegistry({}) };
+	assert.equal(resolveDynamic({ call: 'nope' }, ctx), undefined);
 });


### PR DESCRIPTION
Closes the other half of v1.0's bidirectional function calls. Fixes #5.

## What was broken

The spec requires **fallback routing**: when the renderer evaluates a `FunctionCall` and the name isn't registered locally, it must dispatch `callAgentFunction` rather than treat it as an error. We did this:

```ts
const impl = ctx.functions[ref.call];
if (!impl) {
  console.warn(`[a2ui] unknown function: ${ref.call}`);
  return undefined;
}
```

So any catalog declaring an agent-side function — the spec's own examples are `verifyProviderId` and `checkInventory` — rendered a hole, silently.

## The design problem

`resolveDynamic` is synchronous **by choice** — it's what keeps the protocol suite runnable without a compiler — and agent RPC isn't. Making resolution async would infect every caller, so the async part stays in the reactive layer instead:

- `resolve.ts` reports an unresolved call through an `onUnresolvedFunction` hook, and consults an `agentValues` cache **first** — so a resolved agent function is indistinguishable from a local one.
- The reducer correlates `agentFunctionResponse` by `functionCallId` and writes into that cache. It lives **per-surface**, so `deleteSurface` drops both it and any in-flight calls with no extra bookkeeping. This mirrors `pendingActions`, which already had exactly this shape.

## Two traps worth naming

**Mid-render state mutation.** The hook fires inside `resolveDynamic`, which runs during render — writing reactive state there re-enters the effect currently reading it and trips `effect_update_depth_exceeded`. Requests are queued in a plain (non-reactive) Map and flushed on a microtask.

**An uncached error is a request loop.** The spec has the agent answer `UNKNOWN_FUNCTION` for a name it doesn't recognise. Cache the failure or the next render finds the value still missing and dispatches again — forever, for as long as the component is on screen.

## Details

Args are resolved before dispatch (the agent wants values, not our `{path}` refs), and call identity is canonical, so the same call from three components is **one** round trip regardless of argument key order.

The integration point wasn't `client.context()` as I'd assumed — `Node.svelte` builds its own `EvalContext` per node, and that's where the hook had to go. Found by the end-to-end test failing while the unit tests passed.

## Verification

94 protocol tests · 22 browser tests · typecheck and lint clean. **All three new browser tests verified to fail with the routing removed.**

## Still open from #5

Timeout handling for an agent that simply never replies, and making pending observable to components — a value awaiting a round trip is a third state, distinct from absent and resolved. Both are follow-ups; I'd rather land the routing than bundle them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)