### PR TITLE
feat(transport): turn-based mode for createHttpTransport (#3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ createAgUiTransport({ events, send })
 // streamed updates. Bring your own A2A client; this extracts and wraps.
 createA2aTransport({ events, send })
 
+// Serverless: no persistent stream, so each action's POST response IS the
+// agent's next batch of messages. Turns are serialised; a failed turn goes to
+// onTurnError rather than throwing inside the component that dispatched it.
+createHttpTransport({ url: '/api/agent', turnBased: true, onTurnError })
+
 // Offline: replay a fixture, optionally with a delay between messages.
 createMockTransport(messages, { delayMs: 300 })
 ```

--- a/src/lib/transport/http.ts
+++ b/src/lib/transport/http.ts
@@ -19,6 +19,24 @@ export interface HttpTransportOptions {
 	body?: unknown;
 	/** Where renderer -> agent messages go. Defaults to `url`. */
 	sendUrl?: string;
+	/**
+	 * Turn-based (request/response) mode: read each `send()`'s response as A2UI
+	 * messages and emit them, exactly as `start()` reads its own.
+	 *
+	 * The default assumes an agent that can push down a long-lived stream. A
+	 * serverless agent cannot — two invocations share nothing — so there the
+	 * natural contract is that the response to an action *is* the agent's next
+	 * batch of messages. Without this, that reply is read and discarded, and the
+	 * surface renders its first frame and then goes quiet.
+	 */
+	turnBased?: boolean;
+	/**
+	 * Where a failed turn goes (turn-based mode only). A turn failing is a
+	 * conversation problem, not a renderer fault, so it is reported here instead
+	 * of rejecting inside the component's action dispatch — leaving the host free
+	 * to show the failure in-model. Falls back to `onError`.
+	 */
+	onTurnError?: (error: unknown, message: RendererToAgent) => void;
 	fetch?: typeof globalThis.fetch;
 	signal?: AbortSignal;
 	onError?: (error: unknown) => void;
@@ -36,21 +54,8 @@ export function createHttpTransport(options: HttpTransportOptions): Transport {
 
 	let started = false;
 
-	async function pump(): Promise<void> {
-		const response = await doFetch(options.url, {
-			method: 'POST',
-			headers: {
-				'content-type': 'application/json',
-				accept: 'application/a2ui+json, text/event-stream',
-				...options.headers
-			},
-			body: JSON.stringify(options.body ?? {}),
-			signal: controller.signal
-		});
-
-		if (!response.ok) {
-			throw new Error(`A2UI transport failed: ${response.status} ${response.statusText}`);
-		}
+	/** Read one response body as A2UI messages, negotiating by content-type. */
+	async function consume(response: Response): Promise<void> {
 		if (!response.body) {
 			throw new Error('A2UI transport received a response with no body');
 		}
@@ -74,6 +79,51 @@ export function createHttpTransport(options: HttpTransportOptions): Transport {
 		}
 	}
 
+	async function pump(): Promise<void> {
+		const response = await doFetch(options.url, {
+			method: 'POST',
+			headers: {
+				'content-type': 'application/json',
+				accept: 'application/a2ui+json, text/event-stream',
+				...options.headers
+			},
+			body: JSON.stringify(options.body ?? {}),
+			signal: controller.signal
+		});
+
+		if (!response.ok) {
+			throw new Error(`A2UI transport failed: ${response.status} ${response.statusText}`);
+		}
+		await consume(response);
+	}
+
+	/*
+	 * Turns are serialised. Two actions fired in quick succession would otherwise
+	 * interleave their replies, and `updateComponents` is order-sensitive — the
+	 * later arrival wins per id. Sequential is also what "turn-based" means.
+	 */
+	let turn: Promise<void> = Promise.resolve();
+
+	async function runTurn(message: RendererToAgent): Promise<void> {
+		const response = await doFetch(options.sendUrl ?? options.url, {
+			method: 'POST',
+			headers: {
+				'content-type': 'application/a2ui+json',
+				accept: 'application/a2ui+json, text/event-stream',
+				...options.headers
+			},
+			body: JSON.stringify(message),
+			signal: controller.signal
+		});
+
+		if (!response.ok) {
+			throw new Error(`A2UI turn failed: ${response.status} ${response.statusText}`);
+		}
+		// 204, or any empty body: the agent had nothing to say to this action.
+		if (response.status === 204 || !response.body) return;
+		await consume(response);
+	}
+
 	return {
 		start() {
 			if (started) return;
@@ -86,13 +136,29 @@ export function createHttpTransport(options: HttpTransportOptions): Transport {
 
 		subscribe: emitter.subscribe,
 
-		async send(message: RendererToAgent) {
-			await doFetch(options.sendUrl ?? options.url, {
-				method: 'POST',
-				headers: { 'content-type': 'application/a2ui+json', ...options.headers },
-				body: JSON.stringify(message),
-				signal: controller.signal
-			});
+		send(message: RendererToAgent) {
+			if (!options.turnBased) {
+				return doFetch(options.sendUrl ?? options.url, {
+					method: 'POST',
+					headers: { 'content-type': 'application/a2ui+json', ...options.headers },
+					body: JSON.stringify(message),
+					signal: controller.signal
+				}).then(() => undefined);
+			}
+
+			// Chained, and never rejecting: one failed turn must not poison the
+			// queue or surface as an exception inside the renderer's dispatch.
+			turn = turn.then(() =>
+				runTurn(message).catch((error) => {
+					if (controller.signal.aborted) return;
+					const report =
+						options.onTurnError ??
+						options.onError ??
+						((e: unknown) => console.error('[a2ui] turn failed', e));
+					report(error as never, message as never);
+				})
+			);
+			return turn;
 		},
 
 		close() {

--- a/tests/http.test.ts
+++ b/tests/http.test.ts
@@ -1,0 +1,143 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createHttpTransport } from '../src/lib/transport/http.ts';
+import type { AgentToRenderer, RendererToAgent } from '../src/lib/protocol/types.ts';
+
+const create: AgentToRenderer = { version: 'v1.0', createSurface: { surfaceId: 's' } };
+const update = (text: string): AgentToRenderer => ({
+	version: 'v1.0',
+	updateComponents: { surfaceId: 's', components: [{ id: 'root', component: 'Text', text }] }
+});
+
+/** A JSONL response body, as a serverless turn would return it. */
+function jsonl(messages: AgentToRenderer[], init: ResponseInit = {}): Response {
+	const body = messages.map((m) => JSON.stringify(m) + '\n').join('');
+	return new Response(body, {
+		status: 200,
+		headers: { 'content-type': 'application/a2ui+json' },
+		...init
+	});
+}
+
+const action = (name: string): RendererToAgent => ({
+	version: 'v1.0',
+	action: { name, surfaceId: 's', sourceComponentId: 'b', timestamp: 'now', context: {} }
+});
+
+test('turn-based mode emits the messages returned by send()', async () => {
+	const received: AgentToRenderer[] = [];
+	const transport = createHttpTransport({
+		url: '/agent',
+		turnBased: true,
+		fetch: async () => jsonl([create, update('after the action')])
+	});
+	transport.subscribe((m) => received.push(m));
+
+	await transport.send(action('go'));
+
+	assert.deepEqual(received, [create, update('after the action')]);
+});
+
+test('the default mode still discards the send response', async () => {
+	const received: AgentToRenderer[] = [];
+	const transport = createHttpTransport({
+		url: '/agent',
+		fetch: async () => jsonl([update('ignored')])
+	});
+	transport.subscribe((m) => received.push(m));
+
+	await transport.send(action('go'));
+
+	assert.deepEqual(received, []);
+});
+
+test('turns are serialised, so replies cannot interleave', async () => {
+	const received: string[] = [];
+	let call = 0;
+	const transport = createHttpTransport({
+		url: '/agent',
+		turnBased: true,
+		// The first turn resolves slowly; without chaining, the second would win.
+		fetch: async () => {
+			const mine = ++call;
+			if (mine === 1) await new Promise((r) => setTimeout(r, 30));
+			return jsonl([update(`turn ${mine}`)]);
+		}
+	});
+	transport.subscribe((m) => {
+		const spec = m.updateComponents?.components?.[0] as { text?: string } | undefined;
+		if (spec?.text) received.push(spec.text);
+	});
+
+	const first = transport.send(action('one'));
+	const second = transport.send(action('two'));
+	await Promise.all([first, second]);
+
+	assert.deepEqual(received, ['turn 1', 'turn 2']);
+});
+
+test('a 204 turn is silence, not an error', async () => {
+	const errors: unknown[] = [];
+	const transport = createHttpTransport({
+		url: '/agent',
+		turnBased: true,
+		onTurnError: (e) => errors.push(e),
+		fetch: async () => new Response(null, { status: 204 })
+	});
+
+	await transport.send(action('go'));
+
+	assert.deepEqual(errors, []);
+});
+
+test('a failed turn reaches onTurnError instead of rejecting the dispatch', async () => {
+	const errors: { error: unknown; message: RendererToAgent }[] = [];
+	const transport = createHttpTransport({
+		url: '/agent',
+		turnBased: true,
+		onTurnError: (error, message) => errors.push({ error, message }),
+		fetch: async () => new Response('nope', { status: 500, statusText: 'Server Error' })
+	});
+
+	// Must not throw: a failing conversation is not a renderer fault.
+	await transport.send(action('go'));
+
+	assert.equal(errors.length, 1);
+	assert.match(String((errors[0]!.error as Error).message), /500/);
+	assert.equal(errors[0]!.message.action?.name, 'go');
+});
+
+test('one failed turn does not poison the queue', async () => {
+	const received: AgentToRenderer[] = [];
+	let call = 0;
+	const transport = createHttpTransport({
+		url: '/agent',
+		turnBased: true,
+		onTurnError: () => {},
+		fetch: async () =>
+			++call === 1 ? new Response('nope', { status: 500 }) : jsonl([update('recovered')])
+	});
+	transport.subscribe((m) => received.push(m));
+
+	await transport.send(action('one'));
+	await transport.send(action('two'));
+
+	assert.deepEqual(received, [update('recovered')]);
+});
+
+test('turn-based send negotiates content type like start does', async () => {
+	const received: AgentToRenderer[] = [];
+	const transport = createHttpTransport({
+		url: '/agent',
+		turnBased: true,
+		fetch: async () =>
+			new Response(`data: ${JSON.stringify(update('via sse'))}\n\n`, {
+				headers: { 'content-type': 'text/event-stream' }
+			})
+	});
+	transport.subscribe((m) => received.push(m));
+
+	await transport.send(action('go'));
+
+	assert.deepEqual(received, [update('via sse')]);
+});


### PR DESCRIPTION
Closes #3. Implements the requested shape — an option, not a new transport.

```ts
createHttpTransport({ url: '/api/agent', turnBased: true, onTurnError });
```

`send()` now reads its response the same way `start()` reads its own — content-type negotiated, JSONL or SSE — and emits into the same emitter. The consumption logic is one shared helper, so the two paths can't drift.

**Two decisions the issue left open:**

*Turns are serialised.* Two actions fired in quick succession would otherwise interleave their replies, and `updateComponents` is order-sensitive — later arrival wins per id, so an interleaved pair can leave the surface in the wrong final state. Sequential is also what "turn-based" means. A failed turn doesn't poison the queue.

*A failed turn is reported, not thrown* — to `onTurnError` (falling back to `onError`), never rejecting inside the component's dispatch. That was your suggestion and it's right: a conversation failing is not a renderer fault, and the host should be free to render it in-model. `204` or an empty body counts as silence rather than failure, since an agent may legitimately have nothing to say to an action.

**Verification.** Seven tests cover both modes, the ordering guarantee, the error contract, queue recovery after a failure, and an SSE turn. I mutation-checked the ordering test — removing the chain makes it fail, so it's testing what it claims. Beyond the mocks, I ran it end to end against a real stateless HTTP agent that closes the connection after every response: `start()` yields the opening frame, the action's reply arrives through the same emitter, and the surface updates.

Nothing changes for existing users — without `turnBased`, `send()` behaves exactly as before (there's a test pinning that too).

93 node tests + 19 browser tests green, `check` and `publint` clean.