### PR TITLE
feat(render): name the props waiting on an agent round trip (#5)

### DIFF
--- a/src/lib/catalog/types.ts
+++ b/src/lib/catalog/types.ts
@@ -54,7 +54,18 @@ export interface A2uiComponentProps {
 	actions: Record<string, () => void>;
 	validation: ValidationResult;
 	/** Escape hatch for custom components that need the raw wire spec. */
-	a2ui: { id: string; component: string; spec: ComponentSpec; scope: Scope };
+	a2ui: {
+		id: string;
+		component: string;
+		spec: ComponentSpec;
+		scope: Scope;
+		/**
+		 * Names of props still waiting on an agent round trip — a value that is
+		 * neither absent nor resolved. Show a skeleton for these rather than an
+		 * empty string, or an agent-backed value flashes blank and then pops.
+		 */
+		pending: ReadonlySet<string>;
+	};
 	[key: string]: unknown;
 }
 

--- a/src/lib/render/Node.svelte
+++ b/src/lib/render/Node.svelte
@@ -84,6 +84,6 @@
 		bindings={built.bindings}
 		actions={built.actions}
 		validation={built.validation}
-		a2ui={{ id, component: spec.component, spec, scope }}
+		a2ui={{ id, component: spec.component, spec, scope, pending: built.pending }}
 	/>
 {/if}

--- a/src/lib/render/props.ts
+++ b/src/lib/render/props.ts
@@ -41,6 +41,17 @@ export interface NodeHandlers {
 export interface BuiltNode {
 	/** `false` when a `visible` binding evaluates falsy — render nothing. */
 	visible: boolean;
+	/**
+	 * Props whose value is waiting on an agent round trip.
+	 *
+	 * A value routed to the agent is a THIRD state: not absent, not resolved,
+	 * but on its way. Without naming it, every agent-backed prop renders as
+	 * empty and then pops when the reply lands — which reads as a bug to a user
+	 * and is indistinguishable from "the agent sent nothing" to a component.
+	 * Components use this to show a skeleton for exactly the prop that is
+	 * waiting, rather than for the whole node.
+	 */
+	pending: ReadonlySet<string>;
 	props: Record<string, unknown>;
 	slots: Record<string, SlotContent>;
 	bindings: Record<string, Binding>;
@@ -61,7 +72,24 @@ export function buildNodeProps(
 	const rawKeys = new Set(entry.raw ?? []);
 
 	const props: Record<string, unknown> = {};
+	const pending = new Set<string>();
 	const slots: Record<string, SlotContent> = {};
+
+	/*
+	 * Per-prop context, so an unresolved agent call is attributed to the prop
+	 * that triggered it. Only built when a route to the agent exists — this runs
+	 * for every prop of every node on every render.
+	 */
+	const forProp = (key: string): EvalContext =>
+		ctx.onUnresolvedFunction
+			? {
+					...ctx,
+					onUnresolvedFunction: (ref, callKey) => {
+						pending.add(key);
+						ctx.onUnresolvedFunction?.(ref, callKey);
+					}
+				}
+			: ctx;
 	const bindings: Record<string, Binding> = {};
 	const actions: Record<string, () => void> = {};
 
@@ -88,7 +116,7 @@ export function buildNodeProps(
 			continue;
 		}
 
-		props[key] = rawKeys.has(key) ? value : resolveDynamic(value, ctx);
+		props[key] = rawKeys.has(key) ? value : resolveDynamic(value, forProp(key));
 	}
 
 	const validation = evaluateChecks(spec.checks as CheckRule[] | undefined, ctx);
@@ -96,7 +124,7 @@ export function buildNodeProps(
 	// `visible` defaults to true; only an explicit falsy resolution hides a node.
 	const visible = spec.visible === undefined ? true : props.visible !== false;
 
-	return { visible, props, slots, bindings, actions, validation };
+	return { visible, pending, props, slots, bindings, actions, validation };
 }
 
 /* -------------------------------------------------------------------------- */

--- a/tests/browser/agent-functions.test.ts
+++ b/tests/browser/agent-functions.test.ts
@@ -3,6 +3,8 @@ import { render } from 'vitest-browser-svelte';
 import { A2uiClient } from '../../src/lib/client.svelte.js';
 import Surface from '../../src/lib/render/Surface.svelte';
 import type { RendererToAgent } from '../../src/lib/protocol/types.js';
+import { buildNodeProps } from '../../src/lib/render/props.js';
+import { ROOT_SCOPE } from '../../src/lib/protocol/scope.js';
 import { catalog, SURFACE } from './helpers.js';
 
 /**
@@ -114,3 +116,57 @@ test('a surface torn down mid-flight does not strand the reply', async () => {
 	await settle();
 	expect(client.surfaceIds).not.toContain(SURFACE);
 });
+
+test('pending clears once the agent answers', async () => {
+	/*
+	 * The lifecycle, not just the flag: a prop is pending while the round trip is
+	 * in flight and NOT pending afterwards. A flag that is set but never cleared
+	 * leaves a permanent skeleton over a value that already arrived.
+	 */
+	const { client, sent } = clientWithCapturedOutbound();
+	await render(Surface, { props: { client, catalog, surfaceId: SURFACE } });
+
+	client.ingest({
+		version: 'v1.0',
+		createSurface: {
+			surfaceId: SURFACE,
+			components: [{ id: 'root', component: 'Text', text: { call: 'stockLabel', args: {} } }]
+		}
+	});
+	await settle();
+
+	const pendingWhileWaiting = buildFor(client).pending;
+	expect([...pendingWhileWaiting]).toContain('text');
+
+	const call = sent.find((m) => m.callAgentFunction)!;
+	client.ingest({
+		version: 'v1.0',
+		agentFunctionResponse: {
+			functionCallId: call.callAgentFunction!.functionCallId,
+			value: 'In stock'
+		}
+	});
+	await settle();
+
+	const after = buildFor(client);
+	expect([...after.pending]).toEqual([]);
+	expect(after.props.text).toBe('In stock');
+});
+
+/** Rebuild the root node's props the way the renderer does, to inspect them. */
+function buildFor(client: A2uiClient) {
+	const surface = client.surface(SURFACE)!;
+	const spec = surface.components.root;
+	return buildNodeProps(
+		spec,
+		{ component: (() => {}) as never },
+		{
+			data: surface.dataModel,
+			scope: ROOT_SCOPE,
+			functions: catalog.functions,
+			agentValues: surface.agentValues,
+			onUnresolvedFunction: (ref, key) => client.requestAgentFunction(SURFACE, ref, key)
+		},
+		{ setData: () => {}, dispatch: () => {} }
+	);
+}

--- a/tests/props.test.ts
+++ b/tests/props.test.ts
@@ -310,3 +310,57 @@ test('visible defaults to true and only an explicit false hides the node', () =>
 		'undefined is not an explicit false'
 	);
 });
+
+/* ------------------------------------------- pending agent-backed values */
+
+test('a prop waiting on the agent is named, and only that prop', () => {
+	/*
+	 * A value routed to the agent is a third state: not absent, not resolved.
+	 * Without naming it, an agent-backed prop renders empty and then pops, and
+	 * the component cannot tell that apart from "the agent sent nothing". The
+	 * attribution has to be per-PROP — a skeleton over the whole node when one
+	 * field is late is nearly as bad as no skeleton at all.
+	 */
+	const ctx: EvalContext = {
+		data: { known: 'here' },
+		scope: ROOT_SCOPE,
+		functions: createFunctionRegistry({}),
+		onUnresolvedFunction: () => {}
+	};
+	const spec = {
+		id: 'n1',
+		component: 'Stat',
+		label: 'Stock',
+		caption: { path: '/known' },
+		value: { call: 'stockLevel', args: { sku: 'A-1' } }
+	} as unknown as ComponentSpec;
+
+	const built = buildNodeProps(spec, { component: STUB }, ctx, {
+		setData: () => {},
+		dispatch: () => {}
+	});
+
+	assert.deepEqual([...built.pending], ['value']);
+	assert.equal(built.props.caption, 'here', 'resolved props are untouched');
+	assert.equal(built.props.label, 'Stock', 'literal props are untouched');
+});
+
+test('nothing is pending when there is no route to an agent', () => {
+	// A pure evaluation must not claim to be waiting on anything.
+	const ctx: EvalContext = {
+		data: {},
+		scope: ROOT_SCOPE,
+		functions: createFunctionRegistry({})
+	};
+	const spec = {
+		id: 'n1',
+		component: 'Stat',
+		value: { call: 'stockLevel' }
+	} as unknown as ComponentSpec;
+
+	const built = buildNodeProps(spec, { component: STUB }, ctx, {
+		setData: () => {},
+		dispatch: () => {}
+	});
+	assert.equal(built.pending.size, 0);
+});


### PR DESCRIPTION
The last piece of #5.

A value routed to the agent is a **third state** — not absent, not resolved, but in flight — and until now components couldn't see it. An agent-backed prop rendered empty and then popped when the reply landed: a bug to a user's eye, and indistinguishable from *"the agent sent nothing"* to a component.

## What changed

`buildNodeProps` attributes each unresolved agent call to the **prop** that triggered it and returns the set on `BuiltNode`; `Node` passes it through as `a2ui.pending`.

Per-prop rather than per-node deliberately: a skeleton over an entire card because one figure is late is nearly as bad as no skeleton at all.

The per-prop context is only constructed when a route to the agent exists — this runs for every prop of every node on every render.

## Tests

Three, all verified to fail without the change:

- the attribution itself, and that resolved props are untouched
- the negative case — a pure evaluation must not claim to be waiting on anything
- **the lifecycle**: pending *clears* when the value arrives. A flag that sets but never clears leaves a permanent skeleton over data that already came back, which is worse than the flicker it was meant to fix.

96 protocol tests · 23 browser tests · typecheck and lint clean.

## What this unblocks

Catalogs can now render a skeleton for exactly the prop that's waiting — which is what auri's in-between-states rule (contract principle 8) has always required of bound components, and what agent-side functions would otherwise have quietly broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)